### PR TITLE
Update Dockerfile with json_input instead of excellent-articles dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN ollama serve & while ! curl http://localhost:11434; do sleep 1; done; ollama
 WORKDIR /workspace
 COPY --chmod=644 ./gswikichat ./gswikichat
 COPY --chmod=755 static static
-COPY --chmod=755 excellent-articles excellent-articles
+COPY --chmod=755 json_input json_input
 
 # Container start script
 COPY --chmod=755 start.sh /start.sh


### PR DESCRIPTION
The Dockerfile contained the original directory configuration for jsons: ./excellent-articles.  

I changed this in the Dockerfile from 

COPY --chmod=755 excellent-articles excellent-articles COPY --chmod=755 json_input json_input

which reflects the change to the directory structure where we store jsons.