### PR TITLE
feat: lock versions in docker file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@ frontend/.vscode
 frontend/dist
 frontend/node_modules
 
-gswikichat/__pycache__
+*__pycache__*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+frontend/.vscode
+frontend/dist
+frontend/node_modules
+
+gswikichat/__pycache__


### PR DESCRIPTION
This change locks the versions of
 - ollama (by taking ollama from the upstream docker image)
 - python libraries (by installing them via requirements.txt)

This also reorders the Dockerfile for faster rebuilds when developing
fronend or backend.